### PR TITLE
Add a release build workflow

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+QPAKMAN_URL="https://github.com/bunder/qpakman/archive/refs/tags/v0.67.tar.gz"
+FTEQCC_URL="https://www.fteqcc.org/dl/fteqcc_linux64.zip"
+ERICW_TOOL_URL="https://github.com/ericwa/ericw-tools/releases/download/2.0.0-alpha6/ericw-tools-2.0.0-alpha6-Linux.zip"
+
+repo_root=$(pwd)
+
+sudo apt-get update
+sudo apt-get install -y wget zip unzip build-essential cmake libz-dev libpng-dev python3
+
+# Install QPAKMAN
+QPAKMAN_DIR="/tmp/qpakman"
+mkdir -p "$QPAKMAN_DIR"
+cd "$QPAKMAN_DIR"
+wget -O qpakman.tar.gz "$QPAKMAN_URL"
+tar --strip-components 1 -xf qpakman.tar.gz
+cmake .
+make
+
+# Install FTEQCC
+FTEQCC_DIR="/tmp/fteqcc"
+mkdir -p "$FTEQCC_DIR"
+cd "$FTEQCC_DIR"
+wget -O fteqcc.zip "$FTEQCC_URL"
+unzip fteqcc.zip
+ln -s fteqcc64 fteqcc
+
+# Install ericw-tools
+ERICW_TOOL_DIR="/tmp/ericw-tools"
+mkdir -p "$ERICW_TOOL_DIR"
+cd "$ERICW_TOOL_DIR"
+wget -O ericw-tools.zip "$ERICW_TOOL_URL"
+unzip ericw-tools.zip
+
+# Done
+cd "$repo_root"

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,86 @@
+name: Build and Release
+
+on:
+  release:
+    types: [created]
+  push:
+    branches:
+      - main
+
+# Cancel redundant builds on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: bash -x .github/scripts/install_deps.sh
+    - name: Build release artifacts
+      env:
+        PYTHONUNBUFFERED: 1
+      run: |
+        export PATH="/tmp/qpakman:/tmp/fteqcc:/tmp/ericw-tools:$PATH"
+        python build.py
+    - name: Zip artifacts
+      run: |
+        cd releases
+        zip -r full.zip full
+        zip -r mod.zip mod
+        zip -r lite.zip lite
+        zip -r mod_lite.zip mod_lite
+        zip -r dev.zip dev
+        cd ..
+    - name: Upload asset full.zip
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: releases/full.zip
+        asset_name: full.zip
+        asset_content_type: application/zip
+    - name: Upload asset mod.zip
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: releases/mod.zip
+        asset_name: mod.zip
+        asset_content_type: application/zip
+    - name: Upload asset lite.zip
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: releases/lite.zip
+        asset_name: lite.zip
+        asset_content_type: application/zip
+    - name: Upload asset mod_lite.zip
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: releases/mod_lite.zip
+        asset_name: mod_lite.zip
+        asset_content_type: application/zip
+    - name: Upload asset dev.zip
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: releases/dev.zip
+        asset_name: dev.zip
+        asset_content_type: application/zip

--- a/build.py
+++ b/build.py
@@ -22,7 +22,6 @@ import argparse
 
 # Builds a single file
 def build_file(source_path, destination_path, source_if_missing):
-    print(source_path)
     os.makedirs(os.path.dirname(destination_path), exist_ok=True)
     try:
         shutil.copy(source_path, destination_path)
@@ -95,6 +94,7 @@ def build_release(name, data):
     with open('build_components.json', 'r') as json_file:
         components = json.load(json_file)
         for component_name in data['components']:
+            print(f"Building component {component_name}...")
             build_component(components[component_name])
 
     # Copy stuff over to release folder
@@ -108,7 +108,8 @@ def build_release(name, data):
         command = ['qpakman']
         command.extend(filepaths)
         command.extend(['-o', '../pak0.pak'])
-        subprocess.call(command)
+        print('Creating pak0.pak...')
+        subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
         os.chdir('../../')
         shutil.copy('working/pak0.pak', os.path.join('releases', name, base_dir, 'pak0.pak'))
 
@@ -120,7 +121,8 @@ def build_release(name, data):
         command = ['qpakman']
         command.extend(filepaths)
         command.extend(['-o', '../pak1.pak'])
-        subprocess.call(command)
+        print('Creating pak1.pak...')
+        subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
         os.chdir('../../')
         shutil.copy('working/pak1.pak', os.path.join('releases', name, base_dir, 'pak1.pak'))
 

--- a/lq1/maps/compile_maps.py
+++ b/lq1/maps/compile_maps.py
@@ -107,7 +107,7 @@ def command_make(specific_map=None):
                 continue
 
         setup_compile_args(f)
-        print(f"- {f}")
+        print(f"Compiling {f}")
         devnull = open(os.devnull, 'w')
         subprocess.call([LQ_BSP_PATH] + LQ_BSP_FLAGS.split() + [f"{map_name}.map"],
                         stdout=devnull, cwd=os.path.dirname(f))

--- a/texture-wads/compile_wads.py
+++ b/texture-wads/compile_wads.py
@@ -27,7 +27,9 @@ def make():
         command = ['qpakman']
         command.extend(filepaths)
         command.extend(['-o', f'{wad}.wad'])
-        subprocess.call(command)
+        print(f'Compiling {wad}.wad...')
+        # Suppress output except for errors
+        subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a github ci workflow to build the release artifacts.

- The full release build takes roughly 50min
- On every push to `main` a full release is built so we can be sure everything works once we do decide to create a release
- When there are several pushes to master only the latest will have a running pipeline. Redundant pipelines will be canceled
- When a release is created (via the website) the pipeline will be launched and full release will be built. Additionally the assets will then be uploaded to the release page. They will appear at the usual place once the pipeline completes.
- The release build python script used to spam a lot of text which I had to reduce. This way we can better see what happens and when errors occur.