### PR TITLE
Make artifact available on non-release pipelines

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -34,6 +34,13 @@ jobs:
         zip -r mod_lite.zip mod_lite
         zip -r dev.zip dev
         cd ..
+    - name: Make artifact available on non-release pipelines
+      if: github.event_name != 'release'
+      uses: actions/upload-artifact@v4
+      with:
+        name: full.zip
+        path: releases/full.zip
+        retention-days: 14
     - name: Upload asset full.zip
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
This adds another step to the release build so we can download and test a build when its not a release.

It will be available in the job overview
![image](https://github.com/user-attachments/assets/357a59da-bd96-4d83-92a7-f22e30ad21c4)

or directly in the job log as well