### PR TITLE
Make release build ci run in parallel

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -6,32 +6,26 @@ QPAKMAN_URL="https://github.com/bunder/qpakman/archive/refs/tags/v0.67.tar.gz"
 FTEQCC_URL="https://www.fteqcc.org/dl/fteqcc_linux64.zip"
 ERICW_TOOL_URL="https://github.com/ericwa/ericw-tools/releases/download/2.0.0-alpha6/ericw-tools-2.0.0-alpha6-Linux.zip"
 
-repo_root=$(pwd)
-
 sudo apt-get update
 sudo apt-get install -y wget zip unzip build-essential cmake libz-dev libpng-dev python3
 
+repo_root=$(pwd)
+
+# Install everything in /usr/local/bin to avoid path issues
+cd /usr/local/bin
+
 # Install QPAKMAN
-QPAKMAN_DIR="/tmp/qpakman"
-mkdir -p "$QPAKMAN_DIR"
-cd "$QPAKMAN_DIR"
 wget -O qpakman.tar.gz "$QPAKMAN_URL"
 tar --strip-components 1 -xf qpakman.tar.gz
 cmake .
 make
 
 # Install FTEQCC
-FTEQCC_DIR="/tmp/fteqcc"
-mkdir -p "$FTEQCC_DIR"
-cd "$FTEQCC_DIR"
 wget -O fteqcc.zip "$FTEQCC_URL"
 unzip fteqcc.zip
 ln -s fteqcc64 fteqcc
 
 # Install ericw-tools
-ERICW_TOOL_DIR="/tmp/ericw-tools"
-mkdir -p "$ERICW_TOOL_DIR"
-cd "$ERICW_TOOL_DIR"
 wget -O ericw-tools.zip "$ERICW_TOOL_URL"
 unzip ericw-tools.zip
 

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -7,24 +7,98 @@ on:
     branches:
       - main
 
+env:
+  PYTHONUNBUFFERED: 1
+
 # Cancel redundant builds on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build_release:
+  build_wads:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: bash -x .github/scripts/install_deps.sh
-    - name: Build release artifacts
-      env:
-        PYTHONUNBUFFERED: 1
+    - name: Build wads
+      run: python build.py --compile-wads
+    - name: Upload texture-wads-artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: texture-wads-artifact
+        path: texture-wads/*.wad
+
+  build_progs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: bash -x .github/scripts/install_deps.sh
+    - name: Build progs
+      run: python build.py --compile-progs
+    - name: Upload progs-artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: progs-artifact
+        path: lq1/progs.dat
+
+  build_maps:
+    needs: build_wads
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        map_dir: [brushmodels, dm, e0, e1, e2, e3, e4, misc]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: bash -x .github/scripts/install_deps.sh
+    - name: Download texture-wads-artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: texture-wads-artifact
+        path: texture-wads
+    - name: Build maps
       run: |
-        export PATH="/tmp/qpakman:/tmp/fteqcc:/tmp/ericw-tools:$PATH"
-        python build.py
+        cd lq1/maps
+        python compile_maps.py -d src/${{ matrix.map_dir }}
+    - name: Upload maps-artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: maps-artifact-${{ matrix.map_dir }}
+        if-no-files-found: error
+        path: |
+          lq1/maps/*.bsp
+          lq1/maps/*.lit
+
+  assemble_releases:
+    needs: [build_wads, build_progs, build_maps]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    # Download all the artifacts created so far
+    - name: Download texture-wads-artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: texture-wads-artifact
+        path: texture-wads
+    - name: Download progs-artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: progs-artifact
+        path: lq1/
+    - name: Download maps-artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: maps-artifact-*
+        path: lq1/maps/
+        merge-multiple: true
+    # Assemble the releases from the artifacts
+    - name: Install dependencies
+      run: bash -x .github/scripts/install_deps.sh
+    - name: Build releases
+      run: python build.py --build
     - name: Zip artifacts
       run: |
         cd releases
@@ -34,53 +108,52 @@ jobs:
         zip -r mod_lite.zip mod_lite
         zip -r dev.zip dev
         cd ..
-    - name: Upload asset full.zip
-      if: github.event_name == 'release'
-      uses: actions/upload-release-asset@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Upload the completed release artifacts
+    - name: Upload full.zip
+      uses: actions/upload-artifact@v4
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: releases/full.zip
-        asset_name: full.zip
-        asset_content_type: application/zip
-    - name: Upload asset mod.zip
-      if: github.event_name == 'release'
-      uses: actions/upload-release-asset@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        name: full.zip
+        path: releases/full.zip
+    - name: Upload mod.zip
+      uses: actions/upload-artifact@v4
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: releases/mod.zip
-        asset_name: mod.zip
-        asset_content_type: application/zip
-    - name: Upload asset lite.zip
-      if: github.event_name == 'release'
-      uses: actions/upload-release-asset@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        name: mod.zip
+        path: releases/mod.zip
+    - name: Upload lite.zip
+      uses: actions/upload-artifact@v4
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: releases/lite.zip
-        asset_name: lite.zip
-        asset_content_type: application/zip
-    - name: Upload asset mod_lite.zip
-      if: github.event_name == 'release'
-      uses: actions/upload-release-asset@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        name: lite.zip
+        path: releases/lite.zip
+    - name: Upload mod_lite.zip
+      uses: actions/upload-artifact@v4
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: releases/mod_lite.zip
-        asset_name: mod_lite.zip
-        asset_content_type: application/zip
-    - name: Upload asset dev.zip
-      if: github.event_name == 'release'
-      uses: actions/upload-release-asset@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        name: mod_lite.zip
+        path: releases/mod_lite.zip
+    - name: Upload dev.zip
+      uses: actions/upload-artifact@v4
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: releases/dev.zip
-        asset_name: dev.zip
-        asset_content_type: application/zip
+        name: dev.zip
+        path: releases/dev.zip
+
+  upload_to_release_page:
+    if: github.event_name == 'release'
+    needs: assemble_releases
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release_type: [full, mod, lite, mod_lite, dev]
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.release_type }}.zip
+          path: releases/
+      - name: Upload asset  ${{ matrix.release_type }}.zip
+        uses: actions/upload-release-asset@v1
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: releases/${{ matrix.release_type }}.zip
+          asset_name:  ${{ matrix.release_type }}.zip
+          asset_content_type: application/zip

--- a/lq1/maps/compile_maps.py
+++ b/lq1/maps/compile_maps.py
@@ -89,10 +89,12 @@ def move_file(src, dest_dir):
 
 
 # Command make
-def command_make(specific_map=None):
+def command_make(specific_map=None, specific_dir=None):
     check_for_compiler()
 
-    for f in find('./', '.map'):
+    search_dir = specific_dir if specific_dir else './'
+
+    for f in find(search_dir, '.map'):
         map_name = os.path.splitext(os.path.basename(f))[0]
 
         if specific_map and map_name != specific_map:
@@ -130,7 +132,15 @@ def command_single(map_name):
     if not map_name:
         print("Map name needed, e.g. 'e1m1'")
         return
-    command_make(map_name)
+    command_make(specific_map=map_name)
+
+
+# Command directory
+def command_directory(directory):
+    if not directory:
+        print("Directory name needed, e.g. 'e1'")
+        return
+    command_make(specific_dir=directory)
 
 
 # Command clean
@@ -151,10 +161,11 @@ def command_help():
     Usage: make.py [OPERATION] [FLAGS]
 
     OPERATIONS:
-    -h, help           read this msg :3
-    -c, clean          remove extra files that are left after build
-    -m, make           compile all available map OR
-    -s, single <MAP>   compile a specified single map
+    -h, help            read this msg :3
+    -c, clean           remove extra files that are left after build
+    -m, make            compile all available map OR
+    -s, single <MAP>    compile a specified single map
+    -d, directory <DIR> compile all maps in a specified directory
 
     FLAGS:
     QBSP_FLAGS    override map-specific qbsp flags with a global setting
@@ -176,6 +187,7 @@ def parse_args(args):
     operations = {
         '-m': command_make,
         '-s': lambda: command_single(args[1] if len(args) > 1 else None),
+        '-d': lambda: command_directory(args[1] if len(args) > 1 else None),
         '-c': command_clean,
         '-h': command_help,
     }


### PR DESCRIPTION
This makes the build release pipeline run in parallel. There are separate jobs for the steps and the matrix strategy is used where possible.

![pipeline_overview](https://github.com/user-attachments/assets/23cde925-6fe5-482a-badd-d0651692b575)

The runtime is drastically reduced (~50min to ~10min) and since artifacts need to be passed from job to job they can be downloaded from the actions summary page as well.

## Details

- Dependencies now get installed to `/usr/local/bin` which is in `$PATH` and therefore we can skip the PATH setup
- Created seperate steps for building progs, wads and maps and all is assembled in the end
- Updated some of the actions to newer versions to get rid of deprecation warnings
- Added a change to `compile_maps.py` to enable us to build only maps in a specific directory and thats how I seperated out the build_maps jobs