### PR TITLE
Add flatpak metadata

### DIFF
--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=LibreQuake
+Comment=First person shooter
+Icon=io.github.lavenderdotpet.LibreQuake
+Exec=librequake.sh
+Terminal=false
+Type=Application
+Categories=Game;ActionGame
+Keywords=quake;librequake

--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- https://docs.appimage.org/packaging-guide/optional/appstream.html#using-the-appstream-generator -->
+<!-- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html -->
+<component type="desktop-application">
+  <id>io.github.lavenderdotpet.LibreQuake</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>BSD-3-Clause</project_license>
+  <developer id="sh.queer.librequake">
+    <name>LQ Team</name>
+  </developer>
+  <provides>
+    <id>librequake.desktop</id>
+  </provides>
+  <name>LibreQuake</name>
+  <summary>Free content first-person shooter</summary>
+  <launchable type="desktop-id">io.github.lavenderdotpet.LibreQuake.desktop</launchable>
+  <description>
+    <p>The LibreQuake project aims to create a complete, free content first-person shooter
+      game, but LibreQuake by itself is just the raw material for a game. It must be paired
+      with a compatible engine to be played.</p>
+    <p>There is a massive back catalogue, spanning over two decades, containing thousands of
+      Quake levels and other modifications (“mods”) made by fans of the game. LibreQuake
+      aims to be compatible with these and allows most to be played without the need to use non-free
+      software.</p>
+    <p>Disclaimer: In its current form LibreQuake is a work in progress effort which may
+      include placeholder assets, missing textures or unfinished parts.</p>
+    <p>This release is bundled with the quakespasm sourceport which is released under the
+      GPL-2.0 license. See the Github page for details about used licenses.</p>
+  </description>
+  <url type="homepage">https://librequake.queer.sh/</url>
+  <url type="bugtracker">https://github.com/lavenderdotpet/LibreQuake/issues</url>
+  <url type="contribute">https://github.com/lavenderdotpet/LibreQuake</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>LibreQuake</caption>
+      <image type="source">https://librequake.queer.sh/media/flatpak/storepage04.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>LibreQuake</caption>
+      <image type="source">https://librequake.queer.sh/media/flatpak/storepage02.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>LibreQuake</caption>
+      <image type="source">https://librequake.queer.sh/media/flatpak/storepage03.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>LibreQuake</caption>
+      <image type="source">https://librequake.queer.sh/media/flatpak/storepage05.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>LibreQuake</caption>
+      <image type="source">https://librequake.queer.sh/media/flatpak/storepage01.png</image>
+    </screenshot>
+  </screenshots>
+  <!-- https://hughsie.github.io/oars/generate.html -->
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-fantasy">intense</content_attribute>
+    <content_attribute id="violence-bloodshed">mild</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+  </content_rating>
+  <releases>
+    <release version="v0.07-beta" date="2024-08-16" />
+  </releases>
+</component>


### PR DESCRIPTION
The reviewer in our flatpak submission PR (https://github.com/flathub/flathub/pull/5530) said that these files are supposed to live in the repository here instead of the flatpak pull request.