### PR TITLE
BUILD: Fail map compile on missing textures

### DIFF
--- a/lq1/maps/compile_maps.py
+++ b/lq1/maps/compile_maps.py
@@ -5,6 +5,7 @@
 # MissLavander-LQ & cypress/MotoLegacy & ZungryWare/ZungrySoft
 #
 import os
+import re
 import subprocess
 import sys
 import shutil
@@ -73,15 +74,18 @@ def get_compile_flags(map_path):
 
 
 # Execute command
-def execute_command(command, **kwargs):
+def execute_command(command, fail_on_regex=None, **kwargs):
     try:
-        subprocess.run(
+        result = subprocess.run(
             command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=True,  # Fail on non-zero exit code
             **kwargs
         )
+        if fail_on_regex and re.search(fail_on_regex, result.stdout.decode('utf-8')):
+            print(result.stdout.decode('utf-8'))
+            raise ValueError(f"!!! Command failed: `{fail_on_regex}` found in output")
     except subprocess.CalledProcessError as e:
         print(f"!!! Command failed:\n{e.stdout.decode('utf-8')}")
         raise e
@@ -136,7 +140,8 @@ def command_make(specific_map=None, specific_dir=None):
 
         print(f"Compiling {f}")
 
-        execute_command([LQ_BSP_PATH] + LQ_BSP_FLAGS.split() + [f"{map_name}.map"], cwd=os.path.dirname(f))
+        execute_command([LQ_BSP_PATH] + LQ_BSP_FLAGS.split() + [f"{map_name}.map"],
+                        fail_on_regex=r'WARNING: unable to find texture', cwd=os.path.dirname(f))
 
         if "LQ_SKIP" not in LQ_VIS_FLAGS:
             execute_command([LQ_VIS_PATH] + LQ_VIS_FLAGS.split() + [f"{map_name}.bsp"], cwd=os.path.dirname(f))

--- a/lq1/maps/compile_maps.py
+++ b/lq1/maps/compile_maps.py
@@ -74,21 +74,24 @@ def get_compile_flags(map_path):
 
 
 # Execute command
-def execute_command(command, fail_on_regex=None, **kwargs):
+def execute_command(command, fail_on_regexes=[], **kwargs):
     try:
         result = subprocess.run(
             command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=True,  # Fail on non-zero exit code
-            **kwargs
+            **kwargs,
         )
-        if fail_on_regex and re.search(fail_on_regex, result.stdout.decode('utf-8')):
-            print(result.stdout.decode('utf-8'))
-            raise ValueError(f"!!! Command failed: `{fail_on_regex}` found in output")
     except subprocess.CalledProcessError as e:
         print(f"!!! Command failed:\n{e.stdout.decode('utf-8')}")
         raise e
+
+    stdout_str = result.stdout.decode("utf-8")
+    for pattern in fail_on_regexes:
+        if re.search(pattern, stdout_str):
+            print(stdout_str)
+            raise ValueError(f"!!! Command failed: `{pattern}` found in output")
 
 
 # Find all files in directory with this extension
@@ -140,8 +143,14 @@ def command_make(specific_map=None, specific_dir=None):
 
         print(f"Compiling {f}")
 
-        execute_command([LQ_BSP_PATH] + LQ_BSP_FLAGS.split() + [f"{map_name}.map"],
-                        fail_on_regex=r'WARNING: unable to find texture', cwd=os.path.dirname(f))
+        unwanted_bsp_warnings = [
+            r"WARNING: unable to (find|load) texture",
+            r"WARNING: Couldn't locate texture",
+        ]
+        execute_command(
+            [LQ_BSP_PATH] + LQ_BSP_FLAGS.split() + [f"{map_name}.map"], cwd=os.path.dirname(f),
+            fail_on_regexes=unwanted_bsp_warnings,
+        )
 
         if "LQ_SKIP" not in LQ_VIS_FLAGS:
             execute_command([LQ_VIS_PATH] + LQ_VIS_FLAGS.split() + [f"{map_name}.bsp"], cwd=os.path.dirname(f))


### PR DESCRIPTION
### Description of Changes

This change makes a map compile fail if there are textures missing.

### Visual Sample

I have tested this on the faulty commit in [!173](https://github.com/lavenderdotpet/LibreQuake/pull/173) and it worked

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
