### PR TITLE
QC: Fixed being unable to climb out of water in QW

### DIFF
--- a/qcsrc/client.qc
+++ b/qcsrc/client.qc
@@ -1109,6 +1109,7 @@ void() WaterMove =
 
 void() CheckWaterJump =
 {
+#ifndef __QW__ // QW handles this movement code in the engine for client-side prediction
 	local vector start, end;
 
 // check for a jump-out-of-water
@@ -1137,6 +1138,7 @@ void() CheckWaterJump =
 			return;
 		}
 	}
+#endif
 };
 
 


### PR DESCRIPTION
### Description of Changes
---
During the qwprogs.dat merge, I missed this bit of code that needs to be removed in the `qwprogs.dat`. If this is not removed, the player is unable to jump out of liquids in QW. This is especially problematic in lqdm4, where the player is unable to escape the lava if they fall in.

### Visual Sample
---
## Before
![before](https://github.com/user-attachments/assets/aca0a016-07cf-46aa-a329-e79ba943145a)

## After
![after](https://github.com/user-attachments/assets/ab1955c8-083e-4986-a2e4-4fdbd2366a1d)


### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
