### PR TITLE
QC, DOCS: Added infokey for disabling backpacks in deathmatch

### DIFF
--- a/docs/deathmatch-setup-guide.txt
+++ b/docs/deathmatch-setup-guide.txt
@@ -117,6 +117,7 @@ serverinfo rj 20						Scales rocket jump push force by a factor of 20. (Set to 0
 serverinfo have_axe_only 1				Disables all weapons except for the axe.
 serverinfo buffed_axe 1					Increases the axe's damage.
 serverinfo have_unlimited_ammo 1		Players have unlimited ammo.
+serverinfo disable_backpacks 1			Players do not drop weapon or ammo backpacks on death.
 
 serverinfo have_super_shotgun 1			Players spawn with the Double-Barreled Shotgun.
 serverinfo have_nailgun 1				Players spawn with the Nailgun.

--- a/qcsrc/deathmatch_settings.qc
+++ b/qcsrc/deathmatch_settings.qc
@@ -466,6 +466,17 @@ float() deathmatch_no_mega_health =
     return FALSE;
 };
 
+// Stops players from dropping backpacks on death
+float() deathmatch_no_backpacks =
+{
+#ifdef __QW__ // NQ does not support infokeys
+    if (deathmatch && stof(infokey(world, "disable_backpacks")) != 0)
+        return TRUE;
+#endif
+
+    return FALSE;
+};
+
 // Quad is dropped on death
 float() deathmatch_drop_quad =
 {

--- a/qcsrc/player.qc
+++ b/qcsrc/player.qc
@@ -657,7 +657,7 @@ void() PlayerDie =
 	self.radsuit_finished = 0;
 	self.modelindex = modelindex_player;	// don't use eyes
 
-	if (deathmatch || coop)
+	if ((deathmatch || coop) && !deathmatch_no_backpacks())
 		DropBackpack();
 
 	self.weaponmodel=string_null;


### PR DESCRIPTION
### Description of Changes
---
I've always disliked the backpack mechanic in Quake 1 deathmatch. In duels, it punishes the out-of-control player for picking up ammo since often it will do little more than deliver the in-control player free ammo. I've added an infokey that lets you disable it. They're still enabled by default, of course.

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
