### PR TITLE
CI: Fix fteqcc failure due to outdated glibc version in github runners

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -36,7 +36,7 @@ jobs:
         path: texture-wads/*.wad
 
   build_progs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04  # TODO: change this back to ubuntu-latest once that doesn't point to 22.04 anymore
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies


### PR DESCRIPTION
### Description of Changes

fteqcc nees glibc version 2.38 at minimum. This might be a recent update who knows. However the Ubuntu-latest tag seems to also pick runners using Ubuntu 22.04 which is too old and doesn't satisfy the libc dependency. I set this manually to 24.04 but this should be reverted at some point. Actually it should work right now. This feels like a GitHub bug. They have 24.04 runners available but latest points to something older.

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
