### PR TITLE
AUDIO: Update build_components.json for Wizard sound fix

### DIFF
--- a/build_components.json
+++ b/build_components.json
@@ -236,7 +236,7 @@
             "sound/wizard/hit.wav",
             "sound/wizard/wattack.wav",
             "sound/wizard/wdeath.wav",
-            "sound/wizard/widle.wav",
+            "sound/wizard/widle1.wav",
             "sound/wizard/widle2.wav",
             "sound/wizard/wpain.wav",
             "sound/wizard/wsight.wav",


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit the same standards as the commit name standards. Among many prerequisites, part of that is to ensure you are prefixing the title to reflect the relevant component properly:
* `BUILD`: Modification of our build scripts and/or tools.
* `CI`: Modification of the GitHub Actions Pipeline(s).
* `GFX`: Modification of **game** (not map) textures.
* `GH`: Modifiation of any repository-related elements (screenshots, readme, etc.)
* `MAPS`: Modification of `.map` files.
* `MODELS`: Modification of models, both `.blend` and exported `.mdl`
* `QC`: Modification of QuakeC source code.
* `AUDIO`: Modification of game sound effects or music.
* `WADS`: Modification of **map** textures, to be packed into a `.wad` during the build process.

See "CONTRIBUTING.md" for details.
-->

### Description of Changes
---
well widle1.wav can't be build because widle1.wav doesn't exist in build_components.json
so I fixed it!

### Visual Sample
![image](https://github.com/user-attachments/assets/a738ddf8-1f3b-4569-b73a-d7b23d7e45fd)
this Pull Request solve this problem. 

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
