### PR TITLE
BUILD: Fixed qwprogs.dat not being put into GitHub built releases.

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -11,6 +11,9 @@ on:
       - 'lq1/**'
       - 'qsrc/**'
       - 'texture-wads/**'
+      - 'build.py'
+      - 'build_releases.json'
+      - 'build_components.json'
 
 env:
   PYTHONUNBUFFERED: 1
@@ -47,7 +50,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: progs-artifact
-        path: lq1/progs.dat
+        path: lq1/*progs.dat
 
   build_maps:
     needs: build_wads

--- a/build.py
+++ b/build.py
@@ -14,7 +14,6 @@ import subprocess
 import os
 import json
 import shutil
-import warnings
 import runpy
 import glob
 import argparse
@@ -29,9 +28,9 @@ def build_file(source_path, destination_path, source_if_missing):
         if len(source_if_missing):
             shutil.copy(source_if_missing, destination_path)
         else:
-            # No warning for lit files, since not all maps have them
+            # No error for lit files since not all maps have them
             if not destination_path.endswith(".lit"):
-                warnings.warn(f"Missing file with no substitute: {source_path}")
+                raise ValueError(f"!!! Error: Missing file with no substitute: {source_path}")
 
 
 # Gets a source and dest path from a file entry File. Entries can be a string
@@ -173,12 +172,15 @@ def compile_bsp():
 
 def compile_progs():
     try:
+        print("Compiling progs.dat...")
         subprocess.run(
             ["fteqcc", "qcsrc/progs.src", "-D__LIBREQUAKE__", "-O3"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=True,  # Fail on non-zero exit code
         )
+
+        print("Compiling qwprogs.dat...")
         subprocess.run(
             ["fteqcc", "qcsrc/progs.src", "-D__LIBREQUAKE__", "-D__QW__", "-O3"],
             stdout=subprocess.PIPE,
@@ -191,9 +193,9 @@ def compile_progs():
 
 
 def compile():
+    compile_progs()
     compile_wad()
     compile_bsp()
-    compile_progs()
 
 
 def build():

--- a/build_components.json
+++ b/build_components.json
@@ -44,8 +44,6 @@
         ],
         "files_pak1": [],
         "files_unpacked": [
-            ["-config.cfg", "config.cfg"],
-            "cam.cfg",
             "dev.cfg",
             "zoom90.cfg",
             "zoom120.cfg",


### PR DESCRIPTION
### Description of Changes
---
- Fixed qwprogs.dat not ending up in GitHub built releases.
- Made 'missing asset with no replacement' a build-failing error rather than just a warning. (So we can make sure this doesn't happen again.)
- Removed missing assets from build_components.json.

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
