### PR TITLE
BUILD: Added a release containing the content needed to set up a QW server

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -114,6 +114,7 @@ jobs:
         zip -r mod.zip mod
         zip -r lite.zip lite
         zip -r mod_lite.zip mod_lite
+        zip -r server.zip server
         zip -r dev.zip dev
         cd ..
     # Upload the completed release artifacts
@@ -137,6 +138,11 @@ jobs:
       with:
         name: mod_lite.zip
         path: releases/mod_lite.zip
+    - name: Upload server.zip
+      uses: actions/upload-artifact@v4
+      with:
+        name: server.zip
+        path: releases/server.zip
     - name: Upload dev.zip
       uses: actions/upload-artifact@v4
       with:
@@ -149,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        release_type: [full, mod, lite, mod_lite, dev]
+        release_type: [full, mod, lite, mod_lite, server, dev]
     steps:
       - name: Download release artifacts
         uses: actions/download-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,4 @@ lq-pl.xcf
 !lq1/style_*.cfg
 !lq1/zoom90.cfg
 !lq1/zoom120.cfg
-!lq1/-config.cfg
+!lq1/server_config.cfg

--- a/build_components.json
+++ b/build_components.json
@@ -25,12 +25,30 @@
             "gfx.wad",
             "demo1.dem",
             "demo2.dem",
-            "demo3.dem",
+            "demo3.dem"
+        ],
+        "files_pak1": [],
+        "files_unpacked": []
+    },
+    "progs": {
+        "base_dir": "lq1",
+        "source_if_missing": "",
+        "files_pak0": [
             "progs.dat",
             "qwprogs.dat"
         ],
         "files_pak1": [],
         "files_unpacked": []
+    },
+    "progs_server": {
+        "base_dir": "lq1",
+        "source_if_missing": "",
+        "files_pak0": [],
+        "files_pak1": [],
+        "files_unpacked": [
+            "progs.dat",
+            "qwprogs.dat"
+        ]
     },
     "config": {
         "base_dir": "lq1",
@@ -52,6 +70,15 @@
             "style_ironwail_modern.cfg",
             "style_ironwail_retro.cfg",
             "accessibility.txt"
+        ]
+    },
+    "config_server": {
+        "base_dir": "lq1",
+        "source_if_missing": "",
+        "files_pak0": [],
+        "files_pak1": [],
+        "files_unpacked": [
+            "server_config.cfg"
         ]
     },
     "sounds": {
@@ -491,6 +518,92 @@
             "maps/end.lit"
         ],
         "files_unpacked": []
+    },
+    "maps_server": {
+        "base_dir": "lq1",
+        "source_if_missing": "",
+        "files_pak0": [],
+        "files_pak1": [],
+        "files_unpacked": [
+            ["maps/e0m1.bsp", "maps/lq_e0m1.bsp"],
+            ["maps/e0m1.lit", "maps/lq_e0m1.lit"],
+            ["maps/e0m2.bsp", "maps/lq_e0m2.bsp"],
+            ["maps/e0m2.lit", "maps/lq_e0m2.lit"],
+            ["maps/e0m3.bsp", "maps/lq_e0m3.bsp"],
+            ["maps/e0m3.lit", "maps/lq_e0m3.lit"],
+            ["maps/e0m4.bsp", "maps/lq_e0m4.bsp"],
+            ["maps/e0m4.lit", "maps/lq_e0m4.lit"],
+            ["maps/e0m5.bsp", "maps/lq_e0m5.bsp"],
+            ["maps/e0m5.lit", "maps/lq_e0m5.lit"],
+            ["maps/e0m6.bsp", "maps/lq_e0m6.bsp"],
+            ["maps/e0m6.lit", "maps/lq_e0m6.lit"],
+            ["maps/e0m7.bsp", "maps/lq_e0m7.bsp"],
+            ["maps/e0m7.lit", "maps/lq_e0m7.lit"],
+            ["maps/e0m8.bsp", "maps/lq_e0m8.bsp"],
+            ["maps/e0m8.lit", "maps/lq_e0m8.lit"],
+            ["maps/e1m1.bsp", "maps/lq_e1m1.bsp"],
+            ["maps/e1m1.lit", "maps/lq_e1m1.lit"],
+            ["maps/e1m2.bsp", "maps/lq_e1m2.bsp"],
+            ["maps/e1m2.lit", "maps/lq_e1m2.lit"],
+            ["maps/e1m3.bsp", "maps/lq_e1m3.bsp"],
+            ["maps/e1m3.lit", "maps/lq_e1m3.lit"],
+            ["maps/e1m4.bsp", "maps/lq_e1m4.bsp"],
+            ["maps/e1m4.lit", "maps/lq_e1m4.lit"],
+            ["maps/e1m5.bsp", "maps/lq_e1m5.bsp"],
+            ["maps/e1m5.lit", "maps/lq_e1m5.lit"],
+            ["maps/e1m6.bsp", "maps/lq_e1m6.bsp"],
+            ["maps/e1m6.lit", "maps/lq_e1m6.lit"],
+            ["maps/e1m7.bsp", "maps/lq_e1m7.bsp"],
+            ["maps/e1m7.lit", "maps/lq_e1m7.lit"],
+            ["maps/e1m8.bsp", "maps/lq_e1m8.bsp"],
+            ["maps/e1m8.lit", "maps/lq_e1m8.lit"],
+            ["maps/e2m1.bsp", "maps/lq_e2m1.bsp"],
+            ["maps/e2m1.lit", "maps/lq_e2m1.lit"],
+            ["maps/e2m2.bsp", "maps/lq_e2m2.bsp"],
+            ["maps/e2m2.lit", "maps/lq_e2m2.lit"],
+            ["maps/e2m3.bsp", "maps/lq_e2m3.bsp"],
+            ["maps/e2m3.lit", "maps/lq_e2m3.lit"],
+            ["maps/e2m4.bsp", "maps/lq_e2m4.bsp"],
+            ["maps/e2m4.lit", "maps/lq_e2m4.lit"],
+            ["maps/e2m5.bsp", "maps/lq_e2m5.bsp"],
+            ["maps/e2m5.lit", "maps/lq_e2m5.lit"],
+            ["maps/e2m6.bsp", "maps/lq_e2m6.bsp"],
+            ["maps/e2m6.lit", "maps/lq_e2m6.lit"],
+            ["maps/e2m7.bsp", "maps/lq_e2m7.bsp"],
+            ["maps/e2m7.lit", "maps/lq_e2m7.lit"],
+            ["maps/e3m1.bsp", "maps/lq_e3m1.bsp"],
+            ["maps/e3m1.lit", "maps/lq_e3m1.lit"],
+            ["maps/e3m2.bsp", "maps/lq_e3m2.bsp"],
+            ["maps/e3m2.lit", "maps/lq_e3m2.lit"],
+            ["maps/e3m3.bsp", "maps/lq_e3m3.bsp"],
+            ["maps/e3m3.lit", "maps/lq_e3m3.lit"],
+            ["maps/e3m4.bsp", "maps/lq_e3m4.bsp"],
+            ["maps/e3m4.lit", "maps/lq_e3m4.lit"],
+            ["maps/e3m5.bsp", "maps/lq_e3m5.bsp"],
+            ["maps/e3m5.lit", "maps/lq_e3m5.lit"],
+            ["maps/e3m6.bsp", "maps/lq_e3m6.bsp"],
+            ["maps/e3m6.lit", "maps/lq_e3m6.lit"],
+            ["maps/e3m7.bsp", "maps/lq_e3m7.bsp"],
+            ["maps/e3m7.lit", "maps/lq_e3m7.lit"],
+            ["maps/e4m1.bsp", "maps/lq_e4m1.bsp"],
+            ["maps/e4m1.lit", "maps/lq_e4m1.lit"],
+            ["maps/e4m2.bsp", "maps/lq_e4m2.bsp"],
+            ["maps/e4m2.lit", "maps/lq_e4m2.lit"],
+            ["maps/e4m3.bsp", "maps/lq_e4m3.bsp"],
+            ["maps/e4m3.lit", "maps/lq_e4m3.lit"],
+            ["maps/e4m4.bsp", "maps/lq_e4m4.bsp"],
+            ["maps/e4m4.lit", "maps/lq_e4m4.lit"],
+            ["maps/e4m5.bsp", "maps/lq_e4m5.bsp"],
+            ["maps/e4m5.lit", "maps/lq_e4m5.lit"],
+            ["maps/e4m6.bsp", "maps/lq_e4m6.bsp"],
+            ["maps/e4m6.lit", "maps/lq_e4m6.lit"],
+            ["maps/e4m7.bsp", "maps/lq_e4m7.bsp"],
+            ["maps/e4m7.lit", "maps/lq_e4m7.lit"],
+            ["maps/e4m8.bsp", "maps/lq_e4m8.bsp"],
+            ["maps/e4m8.lit", "maps/lq_e4m8.lit"],
+            ["maps/end.bsp", "maps/lq_end.bsp"],
+            ["maps/end.lit", "maps/lq_end.lit"]
+        ]
     },
     "maps_dm": {
         "base_dir": "lq1",

--- a/build_releases.json
+++ b/build_releases.json
@@ -73,6 +73,7 @@
         "components": [
             "docs",
             "maps_server",
+            "maps_dm",
             "progs_server",
             "config_server"
         ]

--- a/build_releases.json
+++ b/build_releases.json
@@ -5,7 +5,25 @@
         "components": [
             "docs",
             "root",
+            "progs",
             "config",
+            "sounds",
+            "music",
+            "models",
+            "brush_models",
+            "maps_e0",
+            "maps",
+            "maps_dm",
+            "gfx"
+        ]
+    },
+    "mod": {
+        "is_full_release": false,
+        "base_dir": "lq1",
+        "components": [
+            "docs",
+            "root",
+            "progs",
             "sounds",
             "music",
             "models",
@@ -17,11 +35,12 @@
         ]
     },
     "lite": {
-        "is_full_release": false,
+        "is_full_release": true,
         "base_dir": "id1",
         "components": [
             "docs",
             "root",
+            "progs",
             "config",
             "sounds",
             "music",
@@ -32,28 +51,13 @@
             "lite_assets"
         ]
     },
-    "mod": {
-        "is_full_release": false,
-        "base_dir": "lq1",
-        "components": [
-            "docs",
-            "root",
-            "sounds",
-            "music",
-            "models",
-            "brush_models",
-            "maps_e0",
-            "maps",
-            "maps_dm",
-            "gfx"
-        ]
-    },
     "mod_lite": {
         "is_full_release": false,
         "base_dir": "lq1",
         "components": [
             "docs",
             "root",
+            "progs",
             "sounds",
             "music",
             "models",
@@ -61,6 +65,16 @@
             "maps_e0",
             "gfx",
             "lite_assets"
+        ]
+    },
+    "server": {
+        "is_full_release": false,
+        "base_dir": "",
+        "components": [
+            "docs",
+            "maps_server",
+            "progs_server",
+            "config_server"
         ]
     },
     "dev": {

--- a/lq1/default.cfg
+++ b/lq1/default.cfg
@@ -110,7 +110,6 @@ joy_enable 1
 
 // QuakeWorld Server Infokeys
 serverinfo dq 1     // Drop Quad on death in DM
-serverinfo dr 1     // Drop Ring on death in DM
 
 // Engine-specific config Files
 // This is a bit of a hack for cross-engine support

--- a/lq1/server_config.cfg
+++ b/lq1/server_config.cfg
@@ -1,0 +1,42 @@
+// ======================================================= //
+// Default Configuration for LibreQuake Deathmatch Servers //
+// ======================================================= //
+
+// Set up map rotation
+serverinfo lqdm1 lqdm2
+serverinfo lqdm2 lqdm3
+serverinfo lqdm3 lqdm4
+serverinfo lqdm4 lqdm5
+serverinfo lqdm5 lqdm6
+serverinfo lqdm6 lqdm7
+serverinfo lqdm7 lqdm8
+serverinfo lqdm8 lqdm9
+serverinfo lqdm9 lqdm10
+serverinfo lqdm10 lqdm11
+serverinfo lqdm11 lqdm12
+serverinfo lqdm12 lqdm13
+serverinfo lqdm13 lqdm1
+
+// Players drop Crusher Sigil on death
+serverinfo dq 1
+
+// Match ends once a player reaches 15 frags
+fraglimit 15
+
+// Match ends after 10 minutes
+timelimit 10
+
+// Set deathmatch mode to 3
+deathmatch 3
+
+// Move to the next map after the match ends
+samelevel 0
+
+// Set game directory to LibreQuake
+sv_gamedir lq1
+
+// Do not kick players for having an outdated copy of the map
+sv_mapcheck 0
+
+// Move to the first map in the rotation
+map lqdm1

--- a/qcsrc/world.qc
+++ b/qcsrc/world.qc
@@ -193,7 +193,7 @@ void() worldspawn =
 	InitBodyQueue ();
 
 	// custom map attributes
-	if (self.model == "maps/e1m8.bsp")
+	if (self.model == "maps/e1m8.bsp" || self.model == "maps/lq_e1m8.bsp")
 		cvar_set ("sv_gravity", "100");
 	else
 		cvar_set ("sv_gravity", "800");


### PR DESCRIPTION
### Description of Changes
---

- Added a new release that contains content for a QuakeWorld server. This includes the DM maps, the singleplayer maps (with the 'lq_' prefix added to prevent filename collisions with the levels from the original game), the qwprogs.dat, and a starting server config. All maps are unpacked to make it possible to download the maps.
- Made our custom qwprogs.dat enable low gravity for `lq_e1m8.bsp`. This fix will only work for servers running our custom qwprogs.dat, but this is unfortunately the best solution I can think of.
- Added a server_config.cfg which contains suggested default settings for a LibreQuake server.

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
