### PR TITLE
CONFIG: Disabled hacky zfighting fix in FTEQW

### DIFF
--- a/lq1/default_fte.cfg
+++ b/lq1/default_fte.cfg
@@ -19,6 +19,7 @@ m_preset_chosen 1
 com_fullgamename "LibreQuake"
 sb_hidenetquake 1					# Hides netquake servers from browser by default
 sb_showmap 1						# Shows map in server browser
+r_polygonoffset_submodel_map ""		# Disables hacky zfighting fix
 
 // Graphics Style Toggle
 alias lq_style_modern_exec "exec style_fte_modern.cfg"


### PR DESCRIPTION
### Description of Changes
---
Removed FTEQW's hacky and buggy anti-zfighting feature. This was useful for the original game since a lot of the original game's maps had zfighting. Ideally, our maps shouldn't have any zfighting so this setting is unnecessary. This fix was causing problems for a couple of our maps including e2m5 and e1m4.

Fixes the e2m5 issue in this ticket: https://github.com/lavenderdotpet/LibreQuake/issues/162

### Visual Sample
---
![fte-20241123123458-0](https://github.com/user-attachments/assets/21d57b0d-58ce-411e-9f8d-c629022a7f37)


### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
