### PR TITLE
[BUILD] Add launcher for additional engines in Flatpak

### DIFF
--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop
@@ -2,8 +2,44 @@
 Name=LibreQuake
 Comment=First person shooter
 Icon=io.github.lavenderdotpet.LibreQuake
-Exec=librequake.sh
+Exec=io.github.lavenderdotpet.LibreQuake.sh
 Terminal=false
 Type=Application
 Categories=Game;ActionGame
 Keywords=quake;librequake
+Actions=open-user-dir;ironwail;quakespasm;vkquake;qssm
+
+[Desktop Action open-user-dir]
+Name=Open user content directory
+Icon=folder
+Exec=io.github.lavenderdotpet.LibreQuake.open-userdir.sh
+
+[Desktop Action ironwail]
+Name=Ironwail
+Icon=io.github.lavenderdotpet.LibreQuake.quakespasm
+Exec=io.github.lavenderdotpet.LibreQuake.sh ironwail
+
+[Desktop Action quakespasm]
+Name=QuakeSpasm
+Icon=io.github.lavenderdotpet.LibreQuake.quakespasm
+Exec=io.github.lavenderdotpet.LibreQuake.sh quakespasm
+
+[Desktop Action vkquake]
+Name=VkQuake
+Icon=io.github.lavenderdotpet.LibreQuake.quakespasm
+Exec=io.github.lavenderdotpet.LibreQuake.sh vkquake
+
+[Desktop Action qssm]
+Name=QSS-M
+Icon=io.github.lavenderdotpet.LibreQuake.quakespasm
+Exec=io.github.lavenderdotpet.LibreQuake.sh qssm
+
+# [Desktop Action fteqw]
+# Name=FTEQW
+# Icon=io.github.lavenderdotpet.LibreQuake.fteqw
+# Exec=io.github.lavenderdotpet.LibreQuake.sh fteqw
+#
+# [Desktop Action tyrquake]
+# Name=TyrQuake
+# Icon=io.github.lavenderdotpet.LibreQuake.tyrquake
+# Exec=io.github.lavenderdotpet.LibreQuake.sh tyrquake

--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.launcher.desktop
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.launcher.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Name=LibreQuake Launcher
+Comment=First person shooter
+Icon=io.github.lavenderdotpet.LibreQuake
+Exec=io.github.lavenderdotpet.LibreQuake.launcher.sh
+Terminal=false
+Type=Application
+Categories=Game;ActionGame
+Actions=open-user-dir
+
+[Desktop Action open-user-dir]
+Name=Open user content directory
+Icon=folder
+Exec=io.github.lavenderdotpet.LibreQuake.open-userdir.sh

--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.launcher.sh
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.launcher.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+HIDE_LAUNCHER="${XDG_CONFIG_HOME}/lq_hide_launcher"
+if [[ -f "${HIDE_LAUNCHER}" ]]; then
+  rm "${HIDE_LAUNCHER}"
+fi
+io.github.lavenderdotpet.LibreQuake.sh $@

--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.sh
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+ENGINE_CONFIG="${XDG_CONFIG_HOME}/lq_engine"
+HIDE_LAUNCHER="${XDG_CONFIG_HOME}/lq_hide_launcher"
+
+function write_engine_config {
+    if [[ -f ${ENGINE_CONFIG} ]]; then
+      rm "${ENGINE_CONFIG}"
+    fi
+    echo "$1" > "${ENGINE_CONFIG}"
+}
+
+if [[ ! -f "${HIDE_LAUNCHER}" ]]; then
+
+#     FALSE "FTEQW (Multiplayer)" \
+#     FALSE "TyrQuake (Software rendering)" \
+
+  CHOICE=$(zenity --list --radiolist --hide-header --modal --width=600 --height=400 \
+    --column="" --column="" \
+    TRUE "QuakeSpasm (default)" \
+    FALSE "Ironwail (High-performance)" \
+    FALSE "VkQuake (Vulkan renderer)" \
+    FALSE "QSS-M (OpenGL 1.x/2.x for older hardware)" \
+    --title "LibreQuake Launcher" \
+    --text "Select which engine to launch" \
+    --extra-button "Open user content directory" \
+    --ok-label "Launch" \
+    --cancel-label "Quit")
+
+  case "$CHOICE" in
+    "Open mod path")
+      echo "Opening mod path $XDG_DATA_HOME..."
+      xdg-open "$XDG_DATA_HOME"
+      exit 2
+      ;;
+    "QuakeSpasm"*)
+      write_engine_config "quakespasm"
+      ;;
+    "Ironwail"*)
+      write_engine_config "ironwail"
+      ;;
+    "VkQuake"*)
+      write_engine_config "vkquake"
+      ;;
+    "fteqw"*)
+      write_engine_config "fteqw"
+      ;;
+    "qss-m"*)
+      write_engine_config "qssm"
+      ;;
+    "TyrQuake"*)
+      write_engine_config "tyrquake"
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+  touch "${HIDE_LAUNCHER}"
+fi
+
+exitcode=$?
+if [[ $exitcode -ne 0 ]]; then
+  echo "Quitting..."
+elif [[ $exitcode -eq 0 ]]; then
+  if [[ -f "/app/bin/$1" ]]; then
+    ENGINE="$1"
+    GAME_ARGS="${@:2}"
+  else
+    ENGINE=$(cat "${ENGINE_CONFIG}")
+    GAME_ARGS="$@"
+  fi
+  echo "Launching LibreQuake using ${ENGINE} ${GAME_ARGS}..."
+  ${ENGINE} -basedir /app/share/games/librequake ${GAME_ARGS}
+fi

--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.sh
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.sh
@@ -27,9 +27,8 @@ if [[ ! -f "${HIDE_LAUNCHER}" ]]; then
     --cancel-label "Quit")
 
   case "$CHOICE" in
-    "Open mod path")
-      echo "Opening mod path $XDG_DATA_HOME..."
-      xdg-open "$XDG_DATA_HOME"
+    "Open user content directory")
+      ./io.github.lavenderdotpet.LibreQuake.open-userdir.sh
       exit 2
       ;;
     "QuakeSpasm"*)


### PR DESCRIPTION
### Description of Changes
---
This adds right-click options on the .desktop file for directly launching new engines and opening the user content directory, as well as a secondary .desktop file to run the launcher after it has saved the engine selection. Prerequisite for https://github.com/flathub/io.github.lavenderdotpet.LibreQuake/pull/7.

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
