### PR TITLE
BUILD: Fix user content directory button in launcher

### DIFF
--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.sh
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.sh
@@ -28,7 +28,7 @@ if [[ ! -f "${HIDE_LAUNCHER}" ]]; then
 
   case "$CHOICE" in
     "Open user content directory")
-      ./io.github.lavenderdotpet.LibreQuake.open-userdir.sh
+      io.github.lavenderdotpet.LibreQuake.open-userdir.sh
       exit 2
       ;;
     "QuakeSpasm"*)


### PR DESCRIPTION
### Description of Changes
---
This fixes the issue where the "open user content directory" button in the GUI launcher for the Flatpak isn't working.

### Visual Sample

[launcher.webm](https://github.com/user-attachments/assets/f6ae201b-821b-4d27-85e8-d1f2530cff48)


### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
