### PR TITLE
BUILD: Switch default engine in Flatpak launcher to Ironwail

### DIFF
--- a/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.sh
+++ b/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.sh
@@ -16,8 +16,8 @@ if [[ ! -f "${HIDE_LAUNCHER}" ]]; then
 
   CHOICE=$(zenity --list --radiolist --hide-header --modal --width=600 --height=400 \
     --column="" --column="" \
-    TRUE "QuakeSpasm (default)" \
-    FALSE "Ironwail (High-performance)" \
+    TRUE "Ironwail (Default)" \
+    FALSE "QuakeSpasm (Basic modern engine)" \
     FALSE "VkQuake (Vulkan renderer)" \
     FALSE "QSS-M (OpenGL 1.x/2.x for older hardware)" \
     --title "LibreQuake Launcher" \


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit the same standards as the commit name standards. Among many prerequisites, part of that is to ensure you are prefixing the title to reflect the relevant component properly:
* `BUILD`: Modification of our build scripts and/or tools.
* `CI`: Modification of the GitHub Actions Pipeline(s).
* `GFX`: Modification of **game** (not map) textures.
* `GH`: Modifiation of any repository-related elements (screenshots, readme, etc.)
* `MAPS`: Modification of `.map` files.
* `MODELS`: Modification of models, both `.blend` and exported `.mdl`
* `QC`: Modification of QuakeC source code.
* `AUDIO`: Modification of game sound effects or music.
* `WADS`: Modification of **map** textures, to be packed into a `.wad` during the build process.

See "CONTRIBUTING.md" for details.
-->

### Description of Changes
---
As per https://github.com/flathub/io.github.lavenderdotpet.LibreQuake/pull/7, this flips the default engine for LibreQuake to Ironwail from Quakespasm.

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
