### PR TITLE
BUILD: fixed dhit2.wav being mislabled as dhit.wav

### DIFF
--- a/build_components.json
+++ b/build_components.json
@@ -109,7 +109,7 @@
             "sound/buttons/switch04.wav",
             "sound/buttons/switch21.wav",
             "sound/demon/ddeath.wav",
-            "sound/demon/dhit.wav",
+            "sound/demon/dhit2.wav",
             "sound/demon/djump.wav",
             "sound/demon/dland2.wav",
             "sound/demon/dpain1.wav",


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit the same standards as the commit name standards. Among many prerequisites, part of that is to ensure you are prefixing the title to reflect the relevant component properly:
* `BUILD`: Modification of our build scripts and/or tools.
* `CI`: Modification of the GitHub Actions Pipeline(s).
* `GFX`: Modification of **game** (not map) textures.
* `GH`: Modifiation of any repository-related elements (screenshots, readme, etc.)
* `MAPS`: Modification of `.map` files.
* `MODELS`: Modification of models, both `.blend` and exported `.mdl`
* `QC`: Modification of QuakeC source code.
* `AUDIO`: Modification of game sound effects or music.
* `WADS`: Modification of **map** textures, to be packed into a `.wad` during the build process.

See "CONTRIBUTING.md" for details.
-->

### Description of Changes
---

fixed dhit2 being mislabeled as dhit in the build script thus preventing the file from being used in the game
dhit2 being a sound for the moonrat/demon 
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

![image](https://github.com/user-attachments/assets/b00d29ed-a22a-412c-8e36-99b82889ebcc)


### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
