### PR TITLE
GH: Correct "48" to "24"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,4 +100,4 @@ If you are a Collaborator looking to merge a Pull Request, or are just curious a
 * Our CI passes without failure.
 * 24 hours or more have passed since the PR has been marked ready for review.
 
-If the change fixes a critical issue (such as a crash, broken animation, etc.) an exception should be made for the 48 hour rule, **however all other prerequisites must be met!**
+If the change fixes a critical issue (such as a crash, broken animation, etc.) an exception should be made for the 24 hour rule, **however all other prerequisites must be met!**


### PR DESCRIPTION
### Description of Changes

Last year the requirements for submission were changed from 48 Hours to 24 Hours, but the section below it remained unfixed. I was reading the documentation today, and noticed the issue, this should fix this (honestly kinda pointless) issue.

- [x] I have read the LibreQuake contribution guidelines
- [ ] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible