### PR TITLE
CI: Switch to LibreQuake's qpakman

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-QPAKMAN_URL="https://github.com/bunder/qpakman/archive/refs/tags/v0.67.tar.gz"
+QPAKMAN_URL="https://github.com/LibreQuake/qpakman/archive/refs/heads/main.tar.gz"
 FTEQCC_URL="https://www.fteqcc.org/dl/fteqcc_linux64.zip"
 ERICW_TOOL_URL="https://github.com/ericwa/ericw-tools/releases/download/2.0.0-alpha9/ericw-tools-2.0.0-alpha9-Linux.zip"
 


### PR DESCRIPTION
### Description of Changes
---

This change switches qpakman to the main branch of LibreQuake's qpakman repo (https://github.com/LibreQuake/qpakman), which contains some updates with regards to mipmap generation and performance.

### Visual Sample
---

The new qpakman version has slightly more detailed mipmaps, due to featuring a new downscaling algorithm, but the changes are subtle.

### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
