### PR TITLE
BUILD: added branding to releases

### DIFF
--- a/build_components.json
+++ b/build_components.json
@@ -15,7 +15,18 @@
             "docs/misc-docs/COPYING",
             "docs/misc-docs/LibreProgsDeluxe.md",
             "docs/misc-docs/pop.lmp.md",
-            "docs/deathmatch-setup-guide.txt"
+            "docs/deathmatch-setup-guide.txt",
+            "docs/branding/icon.ico",
+            "docs/branding/icon.svg",
+            "docs/branding/icon.pixel.ico",
+            "docs/branding/header.png",
+            "docs/branding/button.png",
+            "docs/branding/steam/capsule-tall.png",
+            "docs/branding/steam/capsule-wide.png",
+            "docs/branding/steam/hero.png",
+            "docs/branding/steam/icon.pixel.png",
+            "docs/branding/steam/icon.png",
+            "docs/branding/steam/logo.png"
         ]
     },
     "root": {


### PR DESCRIPTION


<!-- Note that before you open this Pull Request it should be titled to fit the same standards as the commit name standards. Among many prerequisites, part of that is to ensure you are prefixing the title to reflect the relevant component properly:
* `BUILD`: Modification of our build scripts and/or tools.
* `CI`: Modification of the GitHub Actions Pipeline(s).
* `GFX`: Modification of **game** (not map) textures.
* `GH`: Modifiation of any repository-related elements (screenshots, readme, etc.)
* `MAPS`: Modification of `.map` files.
* `MODELS`: Modification of models, both `.blend` and exported `.mdl`
* `QC`: Modification of QuakeC source code.
* `AUDIO`: Modification of game sound effects or music.
* `WADS`: Modification of **map** textures, to be packed into a `.wad` during the build process.

See "CONTRIBUTING.md" for details.
-->

### Description of Changes
---
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

added the branding assets like boxart and icons to the releases docs folder

fixes https://github.com/lavenderdotpet/LibreQuake/issues/276

### Visual Sample
---
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->
<img width="370" height="483" alt="image" src="https://github.com/user-attachments/assets/5f43ad1a-34f4-4d85-9237-286316dc911d" />

<img width="562" height="629" alt="image" src="https://github.com/user-attachments/assets/71cd5172-0e83-44d2-beb4-395b0c952872" />



### Checklist
---

- [x] I have read the LibreQuake contribution guidelines
- [ ] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact LibreQuake's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
